### PR TITLE
BUG: Bounds type in GenerateData() needs to be of type PadFilterType:…

### DIFF
--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
@@ -35,8 +35,8 @@ ParabolicOpenCloseSafeBorderImageFilter< TInputImage, doOpen, TOutputImage >
   // Allocate the output
   this->AllocateOutputs();
   InputImageConstPointer inputImage;
-  unsigned long          Bounds[ImageDimension];
-  typename TInputImage::SizeType BoundsSize;
+  PadFilterType::SizeType Bounds;
+  typename PadFilterType::SizeType BoundsSize;
   if ( this->m_SafeBorder )
     {
     // need to compute some image statistics and determine the padding


### PR DESCRIPTION
…:SizeType

Using an array of type `long` leads to compilations errors on Windows:

error C2664: 'void itk::PadImageFilter::SetPadLowerBound(const unsigned
	__int64 [])': cannot convert argument 1 from 'unsigned long [2]'
	to 'const itk::Size<2>'