### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkBinaryCloseParaImageFilter.h
+++ b/include/itkBinaryCloseParaImageFilter.h
@@ -72,6 +72,8 @@ class ITK_EXPORT BinaryCloseParaImageFilter:
 
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryCloseParaImageFilter);
+
   /** Standard class type alias. */
   using Self = BinaryCloseParaImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -156,8 +158,6 @@ protected:
   using RCastTypeA = typename itk::GreaterEqualValImageFilter< InternalIntImageType, OutputImageType >;
   using RCastTypeB = typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryCloseParaImageFilter);
-
   RadiusType m_Radius;
   bool       m_Circular;
   bool       m_SafeBorder;

--- a/include/itkBinaryDilateParaImageFilter.h
+++ b/include/itkBinaryDilateParaImageFilter.h
@@ -70,6 +70,8 @@ class ITK_EXPORT BinaryDilateParaImageFilter:
 
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryDilateParaImageFilter);
+
   /** Standard class type alias. */
   using Self = BinaryDilateParaImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -141,8 +143,6 @@ protected:
   using CCastType = typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType >;
   using RCastType = typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryDilateParaImageFilter);
-
   RadiusType m_Radius;
   bool       m_Circular;
 

--- a/include/itkBinaryErodeParaImageFilter.h
+++ b/include/itkBinaryErodeParaImageFilter.h
@@ -71,6 +71,8 @@ class ITK_EXPORT BinaryErodeParaImageFilter:
 
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryErodeParaImageFilter);
+
   /** Standard class type alias. */
   using Self = BinaryErodeParaImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -142,8 +144,6 @@ protected:
   using CCastType = typename itk::GreaterEqualValImageFilter< InternalRealImageType, OutputImageType >;
   using RCastType = typename itk::GreaterEqualValImageFilter< InternalIntImageType, OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryErodeParaImageFilter);
-
   RadiusType m_Radius;
   bool       m_Circular;
 

--- a/include/itkBinaryOpenParaImageFilter.h
+++ b/include/itkBinaryOpenParaImageFilter.h
@@ -72,6 +72,8 @@ class ITK_EXPORT BinaryOpenParaImageFilter:
 
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryOpenParaImageFilter);
+
   /** Standard class type alias. */
   using Self = BinaryOpenParaImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -156,8 +158,6 @@ protected:
   using RCastTypeA = typename itk::GreaterEqualValImageFilter< InternalIntImageType, OutputImageType >;
   using RCastTypeB = typename itk::BinaryThresholdImageFilter< InternalRealImageType, OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryOpenParaImageFilter);
-
   RadiusType m_Radius;
   bool       m_Circular;
   bool       m_SafeBorder;

--- a/include/itkGreaterEqualValImageFilter.h
+++ b/include/itkGreaterEqualValImageFilter.h
@@ -67,6 +67,8 @@ class ITK_EXPORT GreaterEqualValImageFilter:
                              typename TOutputImage::PixelType >   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(GreaterEqualValImageFilter);
+
   /** Standard class type alias. */
   using Self = GreaterEqualValImageFilter;
   using Superclass = UnaryFunctorImageFilter< TInputImage, TOutputImage,
@@ -95,8 +97,6 @@ public:
 protected:
   GreaterEqualValImageFilter() {}
   ~GreaterEqualValImageFilter() override {}
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GreaterEqualValImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkMorphSDTHelperImageFilter.h
+++ b/include/itkMorphSDTHelperImageFilter.h
@@ -83,6 +83,8 @@ class ITK_EXPORT MorphSDTHelperImageFilter:
                                typename TOutputImage::PixelType >   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphSDTHelperImageFilter);
+
   /** Standard class type alias. */
   using Self = MorphSDTHelperImageFilter;
   using Superclass = TernaryFunctorImageFilter< TInputImage1, TInputImage2, TInputImage3, TOutputImage,
@@ -125,8 +127,6 @@ public:
 protected:
   MorphSDTHelperImageFilter() {}
   virtual ~MorphSDTHelperImageFilter() {}
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphSDTHelperImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkMorphologicalDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalDistanceTransformImageFilter.h
@@ -61,6 +61,8 @@ class ITK_EXPORT MorphologicalDistanceTransformImageFilter:
                              TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalDistanceTransformImageFilter);
+
   /** Standard class type alias. */
   using Self = MorphologicalDistanceTransformImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -139,8 +141,6 @@ protected:
   using ErodeType = typename itk::ParabolicErodeImageFilter< OutputImageType, OutputImageType >;
   using SqrtType = typename itk::SqrtImageFilter< OutputImageType, OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalDistanceTransformImageFilter);
-
   InputPixelType               m_OutsideValue;
   typename ErodeType::Pointer  m_Erode;
   typename ThreshType::Pointer m_Thresh;

--- a/include/itkMorphologicalSharpeningImageFilter.h
+++ b/include/itkMorphologicalSharpeningImageFilter.h
@@ -69,6 +69,8 @@ class ITK_EXPORT MorphologicalSharpeningImageFilter:
                              TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSharpeningImageFilter);
+
   /** Standard class type alias. */
   using Self = MorphologicalSharpeningImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -160,8 +162,6 @@ protected:
   using SharpenOpType = typename itk::SharpenOpImageFilter< OutputImageType, OutputImageType, OutputImageType,
                                               OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSharpeningImageFilter);
-
   int m_Iterations;
 
   typename ErodeType::Pointer     m_Erode;

--- a/include/itkMorphologicalSignedDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalSignedDistanceTransformImageFilter.h
@@ -73,6 +73,8 @@ class ITK_EXPORT MorphologicalSignedDistanceTransformImageFilter:
                              TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSignedDistanceTransformImageFilter);
+
   /** Standard class type alias. */
   using Self = MorphologicalSignedDistanceTransformImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -184,8 +186,6 @@ protected:
   using DilateType = typename itk::ParabolicDilateImageFilter< OutputImageType, OutputImageType >;
   using HelperType = typename itk::MorphSDTHelperImageFilter< OutputImageType, OutputImageType >;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSignedDistanceTransformImageFilter);
-
   InputPixelType               m_OutsideValue;
   bool                         m_InsideIsPositive;
   typename ErodeType::Pointer  m_Erode;

--- a/include/itkParabolicCloseImageFilter.h
+++ b/include/itkParabolicCloseImageFilter.h
@@ -53,6 +53,8 @@ class ITK_EXPORT ParabolicCloseImageFilter:
                                                   TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicCloseImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicCloseImageFilter;
   using Superclass = ParabolicOpenCloseSafeBorderImageFilter< TInputImage, false, TOutputImage >;
@@ -89,8 +91,6 @@ protected:
   ParabolicCloseImageFilter(){}
   virtual ~ParabolicCloseImageFilter() {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicCloseImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkParabolicDilateImageFilter.h
+++ b/include/itkParabolicDilateImageFilter.h
@@ -51,6 +51,8 @@ class ITK_EXPORT ParabolicDilateImageFilter:
   public ParabolicErodeDilateImageFilter< TInputImage, true, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicDilateImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicDilateImageFilter;
   using Superclass = ParabolicErodeDilateImageFilter< TInputImage, true, TOutputImage >;
@@ -84,8 +86,6 @@ protected:
   ParabolicDilateImageFilter(){}
   ~ParabolicDilateImageFilter() override {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicDilateImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -86,6 +86,8 @@ class ITK_EXPORT ParabolicErodeDilateImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeDilateImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicErodeDilateImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -192,8 +194,6 @@ protected:
   bool m_UseImageSpacing;
   int  m_ParabolicAlgorithm;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeDilateImageFilter);
-
   RadiusType m_Scale;
 
   typename TInputImage::PixelType m_Extreme;

--- a/include/itkParabolicErodeImageFilter.h
+++ b/include/itkParabolicErodeImageFilter.h
@@ -52,6 +52,8 @@ class ITK_EXPORT ParabolicErodeImageFilter:
                                           TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicErodeImageFilter;
   using Superclass = ParabolicErodeDilateImageFilter< TInputImage, false, TOutputImage >;
@@ -88,8 +90,6 @@ protected:
   ParabolicErodeImageFilter(){}
   ~ParabolicErodeImageFilter() override {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -56,6 +56,8 @@ class ITK_EXPORT ParabolicOpenCloseImageFilter:
   public ImageToImageFilter< TInputImage, TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicOpenCloseImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -159,8 +161,6 @@ protected:
 
   int m_ParabolicAlgorithm;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseImageFilter);
-
   RadiusType m_Scale;
 
   typename TInputImage::PixelType m_Extreme;

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.h
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.h
@@ -37,6 +37,8 @@ class ITK_EXPORT ParabolicOpenCloseSafeBorderImageFilter:
                              TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseSafeBorderImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicOpenCloseSafeBorderImageFilter;
   using Superclass = ImageToImageFilter< TInputImage, TOutputImage >;
@@ -160,8 +162,6 @@ protected:
   ~ParabolicOpenCloseSafeBorderImageFilter() override {}
   int m_ParabolicAlgorithm;
 private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseSafeBorderImageFilter);
-
   typename MorphFilterType::Pointer m_MorphFilt;
   typename PadFilterType::Pointer   m_PadFilt;
   typename CropFilterType::Pointer  m_CropFilt;

--- a/include/itkParabolicOpenImageFilter.h
+++ b/include/itkParabolicOpenImageFilter.h
@@ -52,6 +52,8 @@ class ITK_EXPORT ParabolicOpenImageFilter:
                                                   TOutputImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenImageFilter);
+
   /** Standard class type alias. */
   using Self = ParabolicOpenImageFilter;
   using Superclass = ParabolicOpenCloseSafeBorderImageFilter< TInputImage, true, TOutputImage >;
@@ -85,8 +87,6 @@ protected:
   ParabolicOpenImageFilter(){}
   ~ParabolicOpenImageFilter() override {}
 //   void PrintSelf(std::ostream& os, Indent indent) const;
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenImageFilter);
 };
 } // end namespace itk
 

--- a/include/itkSharpenOpImageFilter.h
+++ b/include/itkSharpenOpImageFilter.h
@@ -89,6 +89,8 @@ class ITK_EXPORT SharpenOpImageFilter:
                                                typename TOutputImage::PixelType >   >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(SharpenOpImageFilter);
+
   /** Standard class type alias. */
   using Self = SharpenOpImageFilter;
   using Superclass = TernaryFunctorImageFilter< TInputImage1, TInputImage2,
@@ -109,8 +111,6 @@ public:
 protected:
   SharpenOpImageFilter() {}
   ~SharpenOpImageFilter() override {}
-private:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SharpenOpImageFilter);
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.