### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -184,7 +184,7 @@ protected:
   unsigned int SplitRequestedRegion(unsigned int i, unsigned int num,
                                     OutputImageRegionType & splitRegion) override;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
   void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError ) override;
 

--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -196,32 +196,8 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
 template< typename TInputImage, bool doDilate, typename TOutputImage >
 void
 ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId)
+::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector< unsigned int > NumberOfRows;
-  InputSizeType size   = outputRegionForThread.GetSize();
-
-  for ( unsigned int i = 0; i < InputImageDimension; i++ )
-    {
-    NumberOfRows.push_back(1);
-    for ( unsigned int d = 0; d < InputImageDimension; d++ )
-      {
-      if ( d != i )
-        {
-        NumberOfRows[i] *= size[d];
-        }
-      }
-    }
-  float progressPerDimension = 1.0 / ImageDimension;
-
-  auto *progress = new ProgressReporter(this,
-                                        threadId,
-                                        NumberOfRows[m_CurrentDimension],
-                                        30,
-                                        m_CurrentDimension * progressPerDimension,
-                                        progressPerDimension);
-
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex< TInputImage  >;
   using OutputIteratorType = ImageLinearIteratorWithIndex< TOutputImage >;
 
@@ -241,15 +217,6 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
   OutputIteratorType      outputIterator(outputImage, region);
   OutputConstIteratorType inputIteratorStage2(outputImage, region);
 
-  // setup the progress reporting
-//   unsigned int numberOfLinesToProcess = 0;
-//   for (unsigned  dd = 0; dd < imageDimension; dd++)
-//     {
-//     numberOfLinesToProcess += region.GetSize()[dd];
-//     }
-
-//   ProgressReporter progress(this,0, numberOfLinesToProcess);
-
   // deal with the first dimension - this should be copied to the
   // output if the scale is 0
   if ( m_CurrentDimension == 0 )
@@ -263,7 +230,7 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
 
       doOneDimension< InputConstIteratorType, OutputIteratorType,
                       RealType, OutputPixelType, doDilate >(inputIterator, outputIterator,
-                                                            *progress, LineLength, 0,
+                                                            LineLength, 0,
                                                             this->m_MagnitudeSign,
                                                             this->m_UseImageSpacing,
                                                             this->m_Extreme,
@@ -299,7 +266,7 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
 
       doOneDimension< OutputConstIteratorType, OutputIteratorType,
                       RealType, OutputPixelType, doDilate >(inputIteratorStage2, outputIterator,
-                                                            *progress, LineLength, m_CurrentDimension,
+                                                            LineLength, m_CurrentDimension,
                                                             this->m_MagnitudeSign,
                                                             this->m_UseImageSpacing,
                                                             this->m_Extreme,

--- a/include/itkParabolicMorphUtils.h
+++ b/include/itkParabolicMorphUtils.h
@@ -20,7 +20,6 @@
 
 #include <itkArray.h>
 
-#include "itkProgressReporter.h"
 namespace itk
 {
 // contact point algorithm
@@ -183,7 +182,6 @@ void DoLineIntAlg(LineBufferType & LineBuf, EnvBufferType & F,
 template< class TInIter, class TOutIter, class RealType,
           class OutputPixelType, bool doDilate >
 void doOneDimension(TInIter & inputIterator, TOutIter & outputIterator,
-                    ProgressReporter & progress,
                     const long LineLength,
                     const unsigned direction,
                     const int m_MagnitudeSign,
@@ -265,7 +263,6 @@ void doOneDimension(TInIter & inputIterator, TOutIter & outputIterator,
       // now onto the next line
       inputIterator.NextLine();
       outputIterator.NextLine();
-      progress.CompletedPixel();
       }
     }
   else
@@ -311,7 +308,6 @@ void doOneDimension(TInIter & inputIterator, TOutIter & outputIterator,
       // now onto the next line
       inputIterator.NextLine();
       outputIterator.NextLine();
-      progress.CompletedPixel();
       }
     }
 }

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -152,7 +152,7 @@ protected:
   unsigned int SplitRequestedRegion(unsigned int i, unsigned int num,
                                     OutputImageRegionType & splitRegion) override;
 
-  void ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
+  void DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
 
   void GenerateInputRequestedRegion() throw( InvalidRequestedRegionError ) override;
 

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -268,32 +268,8 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
 template< typename TInputImage, bool doOpen,  typename TOutputImage >
 void
 ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
-::ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId)
+::DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread)
 {
-  // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector< unsigned int > NumberOfRows;
-  InputSizeType size   = outputRegionForThread.GetSize();
-
-  for ( unsigned int i = 0; i < InputImageDimension; i++ )
-    {
-    NumberOfRows.push_back(1);
-    for ( unsigned int d = 0; d < InputImageDimension; d++ )
-      {
-      if ( d != i )
-        {
-        NumberOfRows[i] *= size[d];
-        }
-      }
-    }
-  float progressPerDimension = 1.0 / ImageDimension;
-
-  auto *progress = new ProgressReporter(this,
-                                        threadId,
-                                        NumberOfRows[m_CurrentDimension],
-                                        30,
-                                        m_CurrentDimension * progressPerDimension,
-                                        progressPerDimension);
-
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex< TInputImage  >;
   using OutputIteratorType = ImageLinearIteratorWithIndex< TOutputImage >;
 
@@ -330,7 +306,7 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
 
         doOneDimension< InputConstIteratorType, OutputIteratorType,
                         RealType, OutputPixelType, !doOpen >(inputIterator, outputIterator,
-                                                             *progress, LineLength, 0,
+                                                             LineLength, 0,
                                                              this->m_MagnitudeSign,
                                                              this->m_UseImageSpacing,
                                                              this->m_Extreme,
@@ -364,7 +340,7 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
 
         doOneDimension< OutputConstIteratorType, OutputIteratorType,
                         RealType, OutputPixelType, !doOpen >(inputIteratorStage2, outputIterator,
-                                                             *progress, LineLength, m_CurrentDimension,
+                                                             LineLength, m_CurrentDimension,
                                                              this->m_MagnitudeSign,
                                                              this->m_UseImageSpacing,
                                                              this->m_Extreme,
@@ -385,7 +361,7 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
 
       doOneDimension< OutputConstIteratorType, OutputIteratorType,
                       RealType, OutputPixelType, doOpen >(inputIteratorStage2, outputIterator,
-                                                          *progress, LineLength, m_CurrentDimension,
+                                                          LineLength, m_CurrentDimension,
                                                           this->m_MagnitudeSign,
                                                           this->m_UseImageSpacing,
                                                           this->m_Extreme,


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The errors stemmed when this gerrit topic got merged:
http://review.source.kitware.com/#/c/23175/

And were later related to the following gerrit-topic:
http://review.source.kitware.com/#/c/23434/

The solution adopted in this patch set was based on the proposal in:
http://review.source.kitware.com/#/c/23439/