### PR TITLE
COMP: Adapt to new multi-threading naming convention.

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -170,7 +170,7 @@ void
 ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
 ::GenerateData(void)
 {
-  ThreadIdType nbthreads = this->GetNumberOfThreads();
+  ThreadIdType nbthreads = this->GetNumberOfWorkUnits();
 
   typename TInputImage::ConstPointer inputImage( this->GetInput () );
   typename TOutputImage::Pointer     outputImage( this->GetOutput() );

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -181,7 +181,7 @@ void
 ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
 ::GenerateData(void)
 {
-  ThreadIdType nbthreads = this->GetNumberOfThreads();
+  ThreadIdType nbthreads = this->GetNumberOfWorkUnits();
 
   //  using InputConstIteratorType = ImageLinearConstIteratorWithIndex< TInputImage  > ;
   //  using OutputIteratorType = ImageLinearIteratorWithIndex< TOutputImage >;
@@ -203,7 +203,7 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
   str.Filter = this;
 
   ProcessObject::MultiThreaderType *multithreader = this->GetMultiThreader();
-  multithreader->SetNumberOfThreads(nbthreads);
+  multithreader->SetNumberOfWorkUnits(nbthreads);
   multithreader->SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution
@@ -237,7 +237,7 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
   // Set up the multithreaded processing
   typename ImageSource< TOutputImage >::ThreadStruct str;
   str.Filter = this;
-  this->GetMultiThreader()->SetNumberOfThreads( this->GetNumberOfThreads() );
+  this->GetMultiThreader()->SetNumberOfWorkUnits( this->GetNumberOfWorkUnits() );
   this->GetMultiThreader()->SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution - stage 1


### PR DESCRIPTION
Adapt to new multi-threading naming convention. Specifically:

- Change `itk::DomainThreader::GetNumberOfThreads` to
  `itk::DomainThreader::GetNumberOfWorkUnits`.
- Change `itk::DomainThreader::SetNumberOfThreads` to
  `itk::DomainThreader::SetNumberOfWorkUnits`.

after commit:
InsightSoftwareConsortium/ITK@ce15429

Addresses deprecation warnings such as:
```
/ITKParabolicMorphology/include/itkParabolicOpenCloseImageFilter.hxx:206:36:
warning: 'virtual void
itk::MultiThreaderBase::SetNumberOfThreads(itk::ThreadIdType)' is
deprecated [-Wdeprecated-declarations]
multithreader->SetNumberOfThreads(nbthreads);
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
In file included from
/ITK/Modules/IO/ImageBase/include/itkImageFileReaderException.h:22:0,
from /ITK/Modules/IO/ImageBase/include/itkImageFileReader.h:20,
from /ITKParabolicMorphology/test/itkParaOpenTest.cxx:19:
/ITK/Modules/Core/Common/include/itkMultiThreaderBase.h:158:32: note:
declared here
itkLegacyMacro( virtual void SetNumberOfThreads( ThreadIdType
numberOfThreads ) )
^
/ITK/Modules/Core/Common/include/itkMacro.h:559:32: note: in definition of
macro 'itkLegacyMacro'
^~~~~~
```

Uncovered by the CI added in PR #15 and Circle CI failures in:
https://circleci.com/gh/InsightSoftwareConsortium/ITKParabolicMorphology/4?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link