### PR TITLE
BUG: Fix multi-threading renaming oversight.

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -184,7 +184,7 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
   str.Filter = this;
 
   ProcessObject::MultiThreaderType *multithreader = this->GetMultiThreader();
-  multithreader->SetNumberOfThreads(nbthreads);
+  multithreader->SetNumberOfWorkUnits(nbthreads);
   multithreader->SetSingleMethod(this->ThreaderCallback, &str);
 
   // multithread the execution


### PR DESCRIPTION
Commit 6182089 missed to change one call to `SetNumberOfThreads` to
`SetNumberOfWorkUnits`.