### PR TITLE
STYLE: Use "typename" for template parameters.

### DIFF
--- a/include/itkGreaterEqualValImageFilter.h
+++ b/include/itkGreaterEqualValImageFilter.h
@@ -30,7 +30,7 @@ namespace itk
 
 namespace Functor
 {
-template< class TInput, class TOutput >
+template< typename TInput, typename TOutput >
 class GEConst
 {
 public:
@@ -58,7 +58,7 @@ private:
 };
 }
 
-template< class TInputImage, class TOutputImage >
+template< typename TInputImage, typename TOutputImage >
 class ITK_EXPORT GreaterEqualValImageFilter:
   public
   UnaryFunctorImageFilter< TInputImage, TOutputImage,

--- a/include/itkMorphSDTHelperImageFilter.h
+++ b/include/itkMorphSDTHelperImageFilter.h
@@ -34,7 +34,7 @@ namespace itk
  */
 namespace Function
 {
-template< class TInput1, class TInput2 = TInput1, class TInput3 = TInput1, class TOutput = TInput1 >
+template< typename TInput1, typename TInput2 = TInput1, typename TInput3 = TInput1, typename TOutput = TInput1 >
 class MorphSDTHelper
 {
 public:
@@ -71,8 +71,8 @@ private:
 };
 }
 
-template< class TInputImage1, class TInputImage2 = TInputImage1, class TInputImage3 = TInputImage1,
-          class TOutputImage = TInputImage1 >
+template< typename TInputImage1, typename TInputImage2 = TInputImage1, typename TInputImage3 = TInputImage1,
+          typename TOutputImage = TInputImage1 >
 class ITK_EXPORT MorphSDTHelperImageFilter:
   public
   TernaryFunctorImageFilter< TInputImage1, TInputImage2, TInputImage3, TOutputImage,

--- a/include/itkParabolicMorphUtils.h
+++ b/include/itkParabolicMorphUtils.h
@@ -23,7 +23,7 @@
 namespace itk
 {
 // contact point algorithm
-template< class LineBufferType, class RealType, bool doDilate >
+template< typename LineBufferType, typename RealType, bool doDilate >
 void DoLineCP(LineBufferType & LineBuf, LineBufferType & tmpLineBuf,
               const RealType magnitude, const RealType m_Extreme)
 {
@@ -74,8 +74,8 @@ void DoLineCP(LineBufferType & LineBuf, LineBufferType & tmpLineBuf,
 // This algorithm has been described a couple of times. First by van
 // den Boomgaard and more recently by Felzenszwalb and Huttenlocher,
 // in the context of generalized distance transform
-template< class LineBufferType, class IndexBufferType,
-          class EnvBufferType, class RealType, bool doDilate >
+template< typename LineBufferType, typename IndexBufferType,
+          typename EnvBufferType, typename RealType, bool doDilate >
 void DoLineIntAlg(LineBufferType & LineBuf, EnvBufferType & F,
                   IndexBufferType & v, EnvBufferType & z,
                   const RealType magnitude)
@@ -179,8 +179,8 @@ void DoLineIntAlg(LineBufferType & LineBuf, EnvBufferType & F,
     }
 }
 
-template< class TInIter, class TOutIter, class RealType,
-          class OutputPixelType, bool doDilate >
+template< typename TInIter, typename TOutIter, typename RealType,
+          typename OutputPixelType, bool doDilate >
 void doOneDimension(TInIter & inputIterator, TOutIter & outputIterator,
                     const long LineLength,
                     const unsigned direction,

--- a/include/itkSharpenOpImageFilter.h
+++ b/include/itkSharpenOpImageFilter.h
@@ -45,7 +45,7 @@ namespace itk
  */
 namespace Function
 {
-template< class TInput1, class TInput2, class TInput3, class TOutput >
+template< typename TInput1, typename TInput2, typename TInput3, typename TOutput >
 class SharpM
 {
 public:


### PR DESCRIPTION
As discussed in:
http://review.source.kitware.com/#/c/12655/

the use of the template keyword "class" was substituted by "typename" in
the toolkit for the reasons stated in that topic.