### PR TITLE
COMP: Prefer C++11 math over vcl_*

### DIFF
--- a/include/itkMorphSDTHelperImageFilter.h
+++ b/include/itkMorphSDTHelperImageFilter.h
@@ -57,12 +57,12 @@ public:
     if ( C > 0 )
       {
       // inside the mask
-      return static_cast< TOutput >( vcl_sqrt( (double)A + m_Val ) );
+      return static_cast< TOutput >( std::sqrt( (double)A + m_Val ) );
       }
     else
       {
       // outside the mask
-      return static_cast< TOutput >( -vcl_sqrt(m_Val - (double)B) );
+      return static_cast< TOutput >( -std::sqrt(m_Val - (double)B) );
       }
   }
 

--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -93,9 +93,9 @@ ParabolicErodeDilateImageFilter< TInputImage, doDilate, TOutputImage >
   // determine the actual number of pieces that will be generated
   auto range = static_cast< double >( requestedRegionSize[splitAxis] );
 
-  auto valuesPerThread = static_cast< unsigned int >( vcl_ceil( range / static_cast< double >( num ) ) );
+  auto valuesPerThread = static_cast< unsigned int >( std::ceil( range / static_cast< double >( num ) ) );
   unsigned int maxThreadIdUsed =
-    static_cast< unsigned int >( vcl_ceil( range / static_cast< double >( valuesPerThread ) ) ) - 1;
+    static_cast< unsigned int >( std::ceil( range / static_cast< double >( valuesPerThread ) ) ) - 1;
 
   // Split the region
   if ( i < maxThreadIdUsed )

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -103,9 +103,9 @@ ParabolicOpenCloseImageFilter< TInputImage, doOpen, TOutputImage >
   auto range = static_cast< double >( requestedRegionSize[splitAxis] );
 
   auto valuesPerThread =
-    static_cast< unsigned int >( vcl_ceil( range / static_cast< double >( num ) ) );
+    static_cast< unsigned int >( std::ceil( range / static_cast< double >( num ) ) );
   unsigned int maxThreadIdUsed =
-    static_cast< unsigned int >( vcl_ceil( range / static_cast< double >( valuesPerThread ) ) ) - 1;
+    static_cast< unsigned int >( std::ceil( range / static_cast< double >( valuesPerThread ) ) ) - 1;
 
   // Split the region
   if ( i < maxThreadIdUsed )


### PR DESCRIPTION
The vcl_ functions are aliases to the C++11 variants,
so just use C++11 directly.