### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/oldtests/dilateBinary3D.cxx
+++ b/oldtests/dilateBinary3D.cxx
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput(inputOrig);
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
   writeIm< IType >(thresh->GetOutput(), argv[5]);
@@ -42,7 +42,7 @@ int main(int argc, char *argv[])
 
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
-  filter->SetRadius( atof(argv[3]) );
+  filter->SetRadius( std::stod(argv[3]) );
 
   writeIm< IType >(filter->GetOutput(), argv[4]);
 

--- a/oldtests/erodeBinary2D.cxx
+++ b/oldtests/erodeBinary2D.cxx
@@ -31,7 +31,7 @@ int main(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput(inputOrig);
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
   writeIm< IType >(thresh->GetOutput(), argv[4]);

--- a/oldtests/perfDT.cxx
+++ b/oldtests/perfDT.cxx
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     return ( EXIT_FAILURE );
     }
 
-  iterations = atoi(argv[1]);
+  iterations = std::stoi(argv[1]);
 
   itk::MultiThreader::SetGlobalMaximumNumberOfThreads(1);
   constexpr int dim = 2;
@@ -56,7 +56,7 @@ int main(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput(input);
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(255);
   writeIm< IType >(thresh->GetOutput(), argv[4]);

--- a/oldtests/perfDT3D.cxx
+++ b/oldtests/perfDT3D.cxx
@@ -28,7 +28,7 @@ int main(int argc, char *argv[])
     return ( EXIT_FAILURE );
     }
 
-  iterations = atoi(argv[1]);
+  iterations = std::stoi(argv[1]);
 
   //itk::MultiThreader::SetGlobalMaximumNumberOfThreads(1);
   constexpr int dim = 3;
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput(input);
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(255);
   writeIm< IType >(thresh->GetOutput(), argv[4]);
@@ -71,7 +71,7 @@ int main(int argc, char *argv[])
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( thresh->GetOutput() );
-  filter->SetOutsideValue( atoi(argv[3]) );
+  filter->SetOutsideValue( std::stoi(argv[3]) );
   filter->SetUseImageSpacing(true);
   filter->SetParabolicAlgorithm(FilterType::CONTACTPOINT);
   //filter->UseContactPointOn();

--- a/oldtests/testClose.cxx
+++ b/oldtests/testClose.cxx
@@ -30,7 +30,7 @@ int main(int, char *argv[])
   FilterType::RadiusType scale;
   //scale[0]=1;
   //scale[1]=0.5;
-  scale.Fill( atof(argv[3]) );
+  scale.Fill( std::stod(argv[3]) );
   filter->SetScale(scale);
 //   itk::SimpleFilterWatcher watcher(filter, "filter");
   itk::TimeProbe NewTime;

--- a/oldtests/testCloseBinary.cxx
+++ b/oldtests/testCloseBinary.cxx
@@ -32,12 +32,12 @@ int main(int argc, char *argv[])
   thresh->SetInput(input);
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
-  thresh->SetUpperThreshold( atoi(argv[4]) );
+  thresh->SetUpperThreshold( std::stoi(argv[4]) );
 
   using FilterType = itk::BinaryCloseParaImageFilter< IType, IType >;
 
   FilterType::Pointer filter = FilterType::New();
-  int                 testrad = atoi(argv[2]);
+  int                 testrad = std::stoi(argv[2]);
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
   filter->SetCircular(true);

--- a/oldtests/testDT.cxx
+++ b/oldtests/testDT.cxx
@@ -22,7 +22,7 @@ int main(int argc, char *argv[])
     return ( EXIT_FAILURE );
     }
 
-  iterations = atoi(argv[1]);
+  iterations = std::stoi(argv[1]);
 
   itk::MultiThreader::SetGlobalMaximumNumberOfThreads(1);
   constexpr int dim = 2;
@@ -38,7 +38,7 @@ int main(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput(input);
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(255);
   writeIm< IType >(thresh->GetOutput(), argv[4]);
@@ -48,7 +48,7 @@ int main(int argc, char *argv[])
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( thresh->GetOutput() );
-  filter->SetOutsideValue( atoi(argv[3]) );
+  filter->SetOutsideValue( std::stoi(argv[3]) );
   filter->Update();
 
   writeIm< FType >(filter->GetOutput(), argv[5]);

--- a/oldtests/testDilateBinary.cxx
+++ b/oldtests/testDilateBinary.cxx
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   using FilterType = itk::BinaryDilateParaImageFilter< IType, IType >;
 
   FilterType::Pointer filter = FilterType::New();
-  int                 testrad = atoi(argv[1]);
+  int                 testrad = std::stoi(argv[1]);
   filter->SetInput(image);
   filter->SetUseImageSpacing(false);
   filter->SetRadius(testrad);

--- a/oldtests/testDistTrans.cxx
+++ b/oldtests/testDistTrans.cxx
@@ -35,7 +35,7 @@ int main(int argc, char *argv[])
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( reader->GetOutput() );
-  filter->SetOutsideValue( atoi(argv[3]) );
+  filter->SetOutsideValue( std::stoi(argv[3]) );
   filter->SetUseImageSpacing(true);
 
   using WriterType = itk::ImageFileWriter< FType >;

--- a/oldtests/testErodeBinary.cxx
+++ b/oldtests/testErodeBinary.cxx
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
   using FilterType = itk::BinaryErodeParaImageFilter< IType, IType >;
 
   FilterType::Pointer filter = FilterType::New();
-  int                 testrad = atoi(argv[1]);
+  int                 testrad = std::stoi(argv[1]);
   filter->SetInput(image);
   filter->SetUseImageSpacing(false);
   filter->SetRadius(testrad);

--- a/oldtests/testOpenBinary.cxx
+++ b/oldtests/testOpenBinary.cxx
@@ -32,12 +32,12 @@ int main(int argc, char *argv[])
   thresh->SetInput(input);
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
-  thresh->SetUpperThreshold( atoi(argv[4]) );
+  thresh->SetUpperThreshold( std::stoi(argv[4]) );
 
   using FilterType = itk::BinaryOpenParaImageFilter< IType, IType >;
 
   FilterType::Pointer filter = FilterType::New();
-  int                 testrad = atoi(argv[2]);
+  int                 testrad = std::stoi(argv[2]);
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
   filter->SetCircular(true);

--- a/oldtests/testSharpen.cxx
+++ b/oldtests/testSharpen.cxx
@@ -25,7 +25,7 @@ int main(int argc, char *argv[])
     return ( EXIT_FAILURE );
     }
 
-  iterations = atoi(argv[1]);
+  iterations = std::stoi(argv[1]);
 
   //itk::MultiThreader::SetGlobalMaximumNumberOfThreads(1);
   constexpr int dim = 2;

--- a/test/itkBinaryCloseParaTest.cxx
+++ b/test/itkBinaryCloseParaTest.cxx
@@ -57,7 +57,7 @@ int itkBinaryCloseParaTest(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput( reader->GetOutput() );
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
   // now to apply the erosion
@@ -67,7 +67,7 @@ int itkBinaryCloseParaTest(int argc, char *argv[])
 
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
-  filter->SetRadius( atof(argv[3]) );
+  filter->SetRadius( std::stod(argv[3]) );
 
   using WriterType = itk::ImageFileWriter< IType >;
   WriterType::Pointer writer = WriterType::New();

--- a/test/itkBinaryDilateParaTest.cxx
+++ b/test/itkBinaryDilateParaTest.cxx
@@ -57,7 +57,7 @@ int itkBinaryDilateParaTest(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput( reader->GetOutput() );
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
   // now to apply the erosion
@@ -67,7 +67,7 @@ int itkBinaryDilateParaTest(int argc, char *argv[])
 
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
-  filter->SetRadius( atof(argv[3]) );
+  filter->SetRadius( std::stod(argv[3]) );
 
   using WriterType = itk::ImageFileWriter< IType >;
   WriterType::Pointer writer = WriterType::New();

--- a/test/itkBinaryErodeParaTest.cxx
+++ b/test/itkBinaryErodeParaTest.cxx
@@ -57,7 +57,7 @@ int itkBinaryErodeParaTest(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput( reader->GetOutput() );
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
   // now to apply the erosion
@@ -67,7 +67,7 @@ int itkBinaryErodeParaTest(int argc, char *argv[])
 
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
-  filter->SetRadius( atof(argv[3]) );
+  filter->SetRadius( std::stod(argv[3]) );
 
   using WriterType = itk::ImageFileWriter< IType >;
   WriterType::Pointer writer = WriterType::New();

--- a/test/itkBinaryOpenParaTest.cxx
+++ b/test/itkBinaryOpenParaTest.cxx
@@ -57,7 +57,7 @@ int itkBinaryOpenParaTest(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput( reader->GetOutput() );
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(1);
   // now to apply the erosion
@@ -67,7 +67,7 @@ int itkBinaryOpenParaTest(int argc, char *argv[])
 
   filter->SetInput( thresh->GetOutput() );
   filter->SetUseImageSpacing(true);
-  filter->SetRadius( atof(argv[3]) );
+  filter->SetRadius( std::stod(argv[3]) );
 
   using WriterType = itk::ImageFileWriter< IType >;
   WriterType::Pointer writer = WriterType::New();

--- a/test/itkParaDTTest.cxx
+++ b/test/itkParaDTTest.cxx
@@ -63,7 +63,7 @@ int itkParaDTTest(int argc, char *argv[])
   ThreshType::Pointer thresh = ThreshType::New();
   thresh->SetInput(input);
 
-  thresh->SetUpperThreshold( atoi(argv[2]) );
+  thresh->SetUpperThreshold( std::stoi(argv[2]) );
   thresh->SetInsideValue(0);
   thresh->SetOutsideValue(255);
 
@@ -73,7 +73,7 @@ int itkParaDTTest(int argc, char *argv[])
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( thresh->GetOutput() );
-  filter->SetOutsideValue( atoi(argv[3]) );
+  filter->SetOutsideValue( std::stoi(argv[3]) );
   try
     {
     filter->Update();

--- a/test/itkParaDilateTest.cxx
+++ b/test/itkParaDilateTest.cxx
@@ -39,7 +39,7 @@ int itkParaDilateTest(int argc, char *argv[])
   float scale(1.0);
   if ( argc > 4 )
     {
-    scale = atof(argv[4]);
+    scale = std::stod(argv[4]);
     }
 
   using ReaderType = itk::ImageFileReader< IType >;

--- a/test/itkParaErodeTest.cxx
+++ b/test/itkParaErodeTest.cxx
@@ -39,7 +39,7 @@ int itkParaErodeTest(int argc, char *argv[])
   float scale(1.0);
   if ( argc > 4 )
     {
-    scale = atof(argv[4]);
+    scale = std::stod(argv[4]);
     }
 
   using ReaderType = itk::ImageFileReader< IType >;

--- a/test/itkParaSharpenTest.cxx
+++ b/test/itkParaSharpenTest.cxx
@@ -42,7 +42,7 @@ int itkParaSharpenTest(int argc, char *argv[])
     return ( EXIT_FAILURE );
     }
 
-  iterations = atoi(argv[1]);
+  iterations = std::stoi(argv[1]);
 
   //itk::MultiThreaderBase::SetGlobalMaximumNumberOfThreads( 1 );
   constexpr int dim = 2;


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/