### PR TITLE
COMP: Future proof vnl_math_XXX function usage.

### DIFF
--- a/include/itkBinaryCloseParaImageFilter.hxx
+++ b/include/itkBinaryCloseParaImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkProgressAccumulator.h"
 #include "itkCropImageFilter.h"
 #include "itkConstantPadImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -86,7 +86,7 @@ BinaryCloseParaImageFilter< TInputImage, TOutputImage >
       {
       typename TInputImage::SpacingValueType tsp = this->GetInput()->GetSpacing()[P];
       R[P] = 0.5 * ( m_Radius[P] * m_Radius[P] ) + tsp * tsp;
-      Pad[P] = ( typename TInputImage::SizeType::SizeValueType )(vnl_math_rnd_halfinttoeven(m_Radius[P] / tsp + 1) + 1);
+      Pad[P] = ( typename TInputImage::SizeType::SizeValueType )(itk::Math::rnd_halfinttoeven(m_Radius[P] / tsp + 1) + 1);
       }
     m_RectErode->SetScale(R);
     m_CircErode->SetScale(R);

--- a/include/itkBinaryOpenParaImageFilter.hxx
+++ b/include/itkBinaryOpenParaImageFilter.hxx
@@ -24,7 +24,7 @@
 #include "itkProgressAccumulator.h"
 #include "itkCropImageFilter.h"
 #include "itkConstantPadImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {
@@ -95,7 +95,7 @@ BinaryOpenParaImageFilter< TInputImage, TOutputImage >
       //R[P] = 0.5 * thisRad * thisRad +
       //this->GetInput()->GetSpacing()[P];
       R[P] = 0.5 * ( m_Radius[P] * m_Radius[P] ) + tsp * tsp;
-      Pad[P] = ( typename TInputImage::SizeType::SizeValueType )(vnl_math_rnd_halfinttoeven(m_Radius[P] / tsp) + 2);
+      Pad[P] = ( typename TInputImage::SizeType::SizeValueType )(itk::Math::rnd_halfinttoeven(m_Radius[P] / tsp) + 2);
       }
     m_RectErode->SetScale(R);
     m_CircErode->SetScale(R);

--- a/include/itkMorphSDTHelperImageFilter.h
+++ b/include/itkMorphSDTHelperImageFilter.h
@@ -19,7 +19,7 @@
 #define itkMorphSDTHelperImageFilter_h
 
 #include "itkTernaryFunctorImageFilter.h"
-#include "vnl/vnl_math.h"
+#include "itkMath.h"
 
 namespace itk
 {


### PR DESCRIPTION
Prefer C++ over aliased names vnl_math_[min|max] -> std::[min|max]
Prefer vnl_math::abs over deprecated alias vnl_math_abs

In all compilers currently supported by VXL, vnl_math_[min|max]
could be replaced with std::[min|max] without loss of
functionality.  This also circumvents part of the backwards
compatibility requirements as vnl_math_ has been recently
replaced with a namespace of vnl_math::.

Since Wed Nov 14 07:42:48 2012:
The vnl_math_* functions use #define aliases to their
vnl_math::* counterparts in the "real" vnl_math:: namespace.

The new syntax should be backwards compatible to
VXL versions as old as 2012.

Prefer to use itk::Math:: over vnl_math:: namespace