### PR TITLE
DOC: Improve Python package information.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,12 +20,12 @@ setup(
     package_dir={'itk': 'itk'},
     download_url=r'https://github.com/InsightSoftwareConsortium/ITKParabolicMorphology',
     description=r'ITK classes for mathematical morphology using parabolic structuring functions',
-    long_description='ITKParabolicMorphology provides mathematical'
-                     'morphological erosion and dilation filters using'
+    long_description='itk-parabolicmorphology provides mathematical '
+                     'morphological erosion and dilation filters using '
                      'parabolic structuring functions.\n'
                      'Please refer to:\n'
-                     'R. Beare, “Morphology with parabolic structuring elements.”,'
-                     'Insight Journal, January-June 2008, http://hdl.handle.net/1926/1370',
+                     'R. Beare, "Morphology with parabolic structuring elements.", '
+                     'Insight Journal, January-June 2008, http://hdl.handle.net/1926/1370.',
     classifiers=[
         "License :: OSI Approved :: Apache Software License",
         "Programming Language :: Python",


### PR DESCRIPTION
Improve Python package information:
- Make the reference in the long description match the package name and
  not the ITK project name.
- Use white spaces to avoid words in two consecutive lines being
  concatenated.
- Prefer ASCII double inverted commas.

Partially addresses:
https://github.com/InsightSoftwareConsortium/ITK/issues/326