### PR TITLE
ENH: Remove unnecessary remote module CMake file.

### DIFF
--- a/ParabolicMorphology.remote.cmake
+++ b/ParabolicMorphology.remote.cmake
@@ -1,5 +1,0 @@
-itk_fetch_module(ParabolicMorphology
-"Classes performing morphology using parabolic functions. Fast distance transforms and binary erosions/dilations/openings/closings by spheres"
-GIT_REPOSITORY https://github.com/richardbeare/parabolicMorphology.git
-GIT_TAG RemoteModule
-)


### PR DESCRIPTION
Remove unnecessary remote CMake file.

The module is already available as an ITK remote module, and this file
dwells in the ITK source tree. Hence, it is unnecessary here.