### PR TITLE
BUG: Fix failing filter and KW-Style tests

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -185,7 +185,7 @@ protected:
   SplitRequestedRegion(unsigned int i, unsigned int num, OutputImageRegionType & splitRegion) override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
   void
   GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;

--- a/include/itkParabolicMorphUtils.h
+++ b/include/itkParabolicMorphUtils.h
@@ -20,6 +20,8 @@
 
 #include <itkArray.h>
 
+#include "itkProgressReporter.h"
+
 namespace itk
 {
 // contact point algorithm
@@ -179,6 +181,7 @@ template <typename TInIter, typename TOutIter, typename RealType, typename Outpu
 void
 doOneDimension(TInIter &      inputIterator,
                TOutIter &     outputIterator,
+               ProgressReporter & progress,
                const long     LineLength,
                const unsigned direction,
                const int      m_MagnitudeSign,
@@ -261,6 +264,7 @@ doOneDimension(TInIter &      inputIterator,
       // now onto the next line
       inputIterator.NextLine();
       outputIterator.NextLine();
+      progress.CompletedPixel();
     }
   }
   else
@@ -306,6 +310,7 @@ doOneDimension(TInIter &      inputIterator,
       // now onto the next line
       inputIterator.NextLine();
       outputIterator.NextLine();
+      progress.CompletedPixel();
     }
   }
 }

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -153,7 +153,7 @@ protected:
   SplitRequestedRegion(unsigned int i, unsigned int num, OutputImageRegionType & splitRegion) override;
 
   void
-  DynamicThreadedGenerateData(const OutputImageRegionType & outputRegionForThread) override;
+  ThreadedGenerateData(const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId) override;
 
   void
   GenerateInputRequestedRegion() throw(InvalidRequestedRegionError) override;

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -49,7 +49,7 @@ namespace itk
  * Australia.  <Richard.Beare@monash.edu>
  *
  **/
-template <typename TInputImage, bool doOpen, typename TOutputImage = TInputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage = TInputImage>
 class ITK_EXPORT ParabolicOpenCloseImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -35,13 +35,13 @@
 
 namespace itk
 {
-template <typename TInputImage, bool doOpen, typename TOutputImage>
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ParabolicOpenCloseImageFilter()
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ParabolicOpenCloseImageFilter()
 {
   this->SetNumberOfRequiredOutputs(1);
   this->SetNumberOfRequiredInputs(1);
   // needs to be selected according to erosion/dilation
-  if (doOpen)
+  if (DoOpen)
   {
     // erosion then dilation
     m_Extreme1 = NumericTraits<PixelType>::max();
@@ -67,9 +67,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ParabolicOpenC
   this->DynamicMultiThreadingOff();
 }
 
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 unsigned int
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::SplitRequestedRegion(
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::SplitRequestedRegion(
   unsigned int            i,
   unsigned int            num,
   OutputImageRegionType & splitRegion)
@@ -126,9 +126,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::SplitRequested
   return maxThreadIdUsed + 1;
 }
 
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::SetScale(ScalarRealType scale)
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::SetScale(ScalarRealType scale)
 {
   RadiusType s;
 
@@ -137,9 +137,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::SetScale(Scala
 }
 
 #if 1
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::GenerateInputRequestedRegion() throw(
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::GenerateInputRequestedRegion() throw(
   InvalidRequestedRegionError)
 {
   // call the superclass' implementation of this method. this should
@@ -157,9 +157,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::GenerateInputR
 #endif
 
 #if 1
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::EnlargeOutputRequestedRegion(DataObject * output)
 {
   auto * out = dynamic_cast<TOutputImage *>(output);
 
@@ -171,9 +171,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::EnlargeOutputR
 
 #endif
 
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::GenerateData()
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::GenerateData()
 {
   ThreadIdType nbthreads = this->GetNumberOfWorkUnits();
 
@@ -261,9 +261,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::GenerateData()
 
 ////////////////////////////////////////////////////////////
 
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ThreadedGenerateData(
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenerateData(
   const OutputImageRegionType & outputRegionForThread, ThreadIdType threadId)
 {
     // compute the number of rows first, so we can setup a progress reporter
@@ -324,7 +324,7 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ThreadedGenera
         unsigned long LineLength = region.GetSize()[0];
         RealType      image_scale = this->GetInput()->GetSpacing()[0];
 
-        doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !doOpen>(
+        doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !DoOpen>(
           inputIterator,
           outputIterator,
           *progress,
@@ -361,7 +361,7 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ThreadedGenera
         unsigned long LineLength = region.GetSize()[m_CurrentDimension];
         RealType      image_scale = this->GetInput()->GetSpacing()[m_CurrentDimension];
 
-        doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !doOpen>(
+        doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !DoOpen>(
           inputIteratorStage2,
           outputIterator,
           *progress,
@@ -385,7 +385,7 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ThreadedGenera
       unsigned long LineLength = region.GetSize()[m_CurrentDimension];
       RealType      image_scale = this->GetInput()->GetSpacing()[m_CurrentDimension];
 
-      doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doOpen>(
+      doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, DoOpen>(
         inputIteratorStage2,
         outputIterator,
         *progress,
@@ -401,9 +401,9 @@ ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::ThreadedGenera
   }
 }
 
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
+ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::PrintSelf(std::ostream & os, Indent indent) const
 {
   Superclass::PrintSelf(os, indent);
   if (m_UseImageSpacing)

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.h
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.h
@@ -29,7 +29,7 @@
 
 namespace itk
 {
-template <typename TInputImage, bool doOpen, typename TOutputImage = TInputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage = TInputImage>
 class ITK_EXPORT ParabolicOpenCloseSafeBorderImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
@@ -149,7 +149,7 @@ protected:
   void
   PrintSelf(std::ostream & os, Indent indent) const override;
 
-  using MorphFilterType = ParabolicOpenCloseImageFilter<TInputImage, doOpen, TOutputImage>;
+  using MorphFilterType = ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>;
   using PadFilterType = ConstantPadImageFilter<TInputImage, TInputImage>;
   using CropFilterType = CropImageFilter<TOutputImage, TOutputImage>;
   using StatsFilterType = StatisticsImageFilter<InputImageType>;

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
@@ -23,9 +23,9 @@
 
 namespace itk
 {
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>::GenerateData()
+ParabolicOpenCloseSafeBorderImageFilter<TInputImage, DoOpen, TOutputImage>::GenerateData()
 {
   ProgressAccumulator::Pointer progress = ProgressAccumulator::New();
 
@@ -66,7 +66,7 @@ ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>::Gene
     m_PadFilt->SetPadUpperBound(Bounds);
 
     // need to select between opening and closing here
-    if (doOpen)
+    if (DoOpen)
     {
       // m_PadFilt->SetConstant(NumericTraits<InputPixelType>::max());
       m_PadFilt->SetConstant(m_StatsFilt->GetMaximum());
@@ -113,9 +113,9 @@ ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>::Gene
   }
 }
 
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>::Modified() const
+ParabolicOpenCloseSafeBorderImageFilter<TInputImage, DoOpen, TOutputImage>::Modified() const
 {
   Superclass::Modified();
   m_MorphFilt->Modified();
@@ -125,9 +125,9 @@ ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>::Modi
 }
 
 ///////////////////////////////////
-template <typename TInputImage, bool doOpen, typename TOutputImage>
+template <typename TInputImage, bool DoOpen, typename TOutputImage>
 void
-ParabolicOpenCloseSafeBorderImageFilter<TInputImage, doOpen, TOutputImage>::PrintSelf(std::ostream & os,
+ParabolicOpenCloseSafeBorderImageFilter<TInputImage, DoOpen, TOutputImage>::PrintSelf(std::ostream & os,
                                                                                       Indent         indent) const
 {
   os << indent << "SafeBorder: " << m_SafeBorder << std::endl;


### PR DESCRIPTION
Changes `doOpen to DoOpen` to fix failing KW-Style test.

For the filters, they had to be reverted to the classic ITK multi-threading system, because they utilize a custom region splitter. This required:

- `DynamiicMultThreadingOn()` to `DynamiicMultThreadingOff()` in filter's constructor.

- Changing method `DynamicThreadedGenerateData()` to `ThreadedGenerateData()` with `theadId` passed as a parameter.

    -  Includes progress reporting.

- Adding `ProgressReporter` object as parameter to `doOneDimension()` methods.