### PR TITLE
STYLE: Rename ITK_DISALLOW_COPY_AND_ASSIGN to ITK_DISALLOW_COPY_A…

### DIFF
--- a/include/itkBinaryCloseParaImageFilter.h
+++ b/include/itkBinaryCloseParaImageFilter.h
@@ -70,7 +70,7 @@ class ITK_TEMPLATE_EXPORT BinaryCloseParaImageFilter : public ImageToImageFilter
 
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryCloseParaImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BinaryCloseParaImageFilter);
 
   /** Standard class type alias. */
   using Self = BinaryCloseParaImageFilter;

--- a/include/itkBinaryDilateParaImageFilter.h
+++ b/include/itkBinaryDilateParaImageFilter.h
@@ -68,7 +68,7 @@ class ITK_TEMPLATE_EXPORT BinaryDilateParaImageFilter : public ImageToImageFilte
 
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryDilateParaImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BinaryDilateParaImageFilter);
 
   /** Standard class type alias. */
   using Self = BinaryDilateParaImageFilter;

--- a/include/itkBinaryErodeParaImageFilter.h
+++ b/include/itkBinaryErodeParaImageFilter.h
@@ -69,7 +69,7 @@ class ITK_TEMPLATE_EXPORT BinaryErodeParaImageFilter : public ImageToImageFilter
 
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryErodeParaImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BinaryErodeParaImageFilter);
 
   /** Standard class type alias. */
   using Self = BinaryErodeParaImageFilter;

--- a/include/itkBinaryOpenParaImageFilter.h
+++ b/include/itkBinaryOpenParaImageFilter.h
@@ -70,7 +70,7 @@ class ITK_TEMPLATE_EXPORT BinaryOpenParaImageFilter : public ImageToImageFilter<
 
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(BinaryOpenParaImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(BinaryOpenParaImageFilter);
 
   /** Standard class type alias. */
   using Self = BinaryOpenParaImageFilter;

--- a/include/itkGreaterEqualValImageFilter.h
+++ b/include/itkGreaterEqualValImageFilter.h
@@ -72,7 +72,7 @@ class ITK_TEMPLATE_EXPORT GreaterEqualValImageFilter
                                    Functor::GEConst<typename TInputImage::PixelType, typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(GreaterEqualValImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(GreaterEqualValImageFilter);
 
   /** Standard class type alias. */
   using Self = GreaterEqualValImageFilter;

--- a/include/itkMorphSDTHelperImageFilter.h
+++ b/include/itkMorphSDTHelperImageFilter.h
@@ -93,7 +93,7 @@ class ITK_TEMPLATE_EXPORT MorphSDTHelperImageFilter
                                                               typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphSDTHelperImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphSDTHelperImageFilter);
 
   /** Standard class type alias. */
   using Self = MorphSDTHelperImageFilter;

--- a/include/itkMorphologicalDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalDistanceTransformImageFilter.h
@@ -59,7 +59,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT MorphologicalDistanceTransformImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalDistanceTransformImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphologicalDistanceTransformImageFilter);
 
   /** Standard class type alias. */
   using Self = MorphologicalDistanceTransformImageFilter;

--- a/include/itkMorphologicalSharpeningImageFilter.h
+++ b/include/itkMorphologicalSharpeningImageFilter.h
@@ -67,7 +67,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT MorphologicalSharpeningImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSharpeningImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphologicalSharpeningImageFilter);
 
   /** Standard class type alias. */
   using Self = MorphologicalSharpeningImageFilter;

--- a/include/itkMorphologicalSignedDistanceTransformImageFilter.h
+++ b/include/itkMorphologicalSignedDistanceTransformImageFilter.h
@@ -71,7 +71,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT MorphologicalSignedDistanceTransformImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(MorphologicalSignedDistanceTransformImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(MorphologicalSignedDistanceTransformImageFilter);
 
   /** Standard class type alias. */
   using Self = MorphologicalSignedDistanceTransformImageFilter;

--- a/include/itkParabolicCloseImageFilter.h
+++ b/include/itkParabolicCloseImageFilter.h
@@ -51,7 +51,7 @@ class ITK_TEMPLATE_EXPORT ParabolicCloseImageFilter
   : public ParabolicOpenCloseSafeBorderImageFilter<TInputImage, false, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicCloseImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicCloseImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicCloseImageFilter;

--- a/include/itkParabolicDilateImageFilter.h
+++ b/include/itkParabolicDilateImageFilter.h
@@ -49,7 +49,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ParabolicDilateImageFilter : public ParabolicErodeDilateImageFilter<TInputImage, true, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicDilateImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicDilateImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicDilateImageFilter;

--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -83,7 +83,7 @@ template <typename TInputImage, bool doDilate, typename TOutputImage = TInputIma
 class ITK_TEMPLATE_EXPORT ParabolicErodeDilateImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeDilateImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicErodeDilateImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicErodeDilateImageFilter;

--- a/include/itkParabolicErodeImageFilter.h
+++ b/include/itkParabolicErodeImageFilter.h
@@ -49,7 +49,7 @@ template <typename TInputImage, typename TOutputImage = TInputImage>
 class ITK_TEMPLATE_EXPORT ParabolicErodeImageFilter : public ParabolicErodeDilateImageFilter<TInputImage, false, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicErodeImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicErodeImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicErodeImageFilter;

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -53,7 +53,7 @@ template <typename TInputImage, bool DoOpen, typename TOutputImage = TInputImage
 class ITK_TEMPLATE_EXPORT ParabolicOpenCloseImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicOpenCloseImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicOpenCloseImageFilter;

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.h
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.h
@@ -33,7 +33,7 @@ template <typename TInputImage, bool DoOpen, typename TOutputImage = TInputImage
 class ITK_TEMPLATE_EXPORT ParabolicOpenCloseSafeBorderImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenCloseSafeBorderImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicOpenCloseSafeBorderImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicOpenCloseSafeBorderImageFilter;

--- a/include/itkParabolicOpenImageFilter.h
+++ b/include/itkParabolicOpenImageFilter.h
@@ -50,7 +50,7 @@ class ITK_TEMPLATE_EXPORT ParabolicOpenImageFilter
   : public ParabolicOpenCloseSafeBorderImageFilter<TInputImage, true, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(ParabolicOpenImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(ParabolicOpenImageFilter);
 
   /** Standard class type alias. */
   using Self = ParabolicOpenImageFilter;

--- a/include/itkSharpenOpImageFilter.h
+++ b/include/itkSharpenOpImageFilter.h
@@ -96,7 +96,7 @@ class ITK_TEMPLATE_EXPORT SharpenOpImageFilter
                                                       typename TOutputImage::PixelType>>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(SharpenOpImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(SharpenOpImageFilter);
 
   /** Standard class type alias. */
   using Self = SharpenOpImageFilter;


### PR DESCRIPTION
This PR fixes changes made in [#2053](https://github.com/InsightSoftwareConsortium/ITK/pull/2053/commits/4eac1a0cfb456fad1e3894173a41d7c7de49b08f). Essentially, `ITK_DISALLOW_COPY_AND_ASSIGN` has been changed to `ITK_DISALLOW_COPY_AND_MOVE` to more accurately convey the actions taking place. `ITK_DISALLOW_COPY_AND_ASSIGN` will **only** be used if `ITK_FUTURE_LEGACY_REMOVE=OFF`.

**NOTE:** These changes will cause the GitHub Actions to break, because they currently build `ITK v5.1.0`. The errors persist with `v5.1.1` as well (will update to newest version in separate PR). When tested locally against `master`, I get all tests to pass. The case is the same for the remaining 39 remote modules.