### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkBinaryCloseParaImageFilter.hxx
+++ b/include/itkBinaryCloseParaImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkBinaryCloseParaImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
-#include "itkBinaryCloseParaImageFilter.h"
 #include "itkParabolicErodeImageFilter.h"
 #include "itkProgressAccumulator.h"
 #include "itkCropImageFilter.h"

--- a/include/itkBinaryDilateParaImageFilter.hxx
+++ b/include/itkBinaryDilateParaImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkBinaryDilateParaImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
-#include "itkBinaryDilateParaImageFilter.h"
 #include "itkParabolicDilateImageFilter.h"
 #include "itkProgressAccumulator.h"
 

--- a/include/itkBinaryErodeParaImageFilter.hxx
+++ b/include/itkBinaryErodeParaImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkBinaryErodeParaImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
-#include "itkBinaryErodeParaImageFilter.h"
 #include "itkParabolicErodeImageFilter.h"
 #include "itkProgressAccumulator.h"
 

--- a/include/itkBinaryOpenParaImageFilter.hxx
+++ b/include/itkBinaryOpenParaImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkBinaryOpenParaImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
-#include "itkBinaryOpenParaImageFilter.h"
 #include "itkParabolicErodeImageFilter.h"
 #include "itkProgressAccumulator.h"
 #include "itkCropImageFilter.h"

--- a/include/itkMorphologicalDistanceTransformImageFilter.hxx
+++ b/include/itkMorphologicalDistanceTransformImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMorphologicalDistanceTransformImageFilter_hxx
 #define itkMorphologicalDistanceTransformImageFilter_hxx
 
-#include "itkMorphologicalDistanceTransformImageFilter.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk

--- a/include/itkMorphologicalSharpeningImageFilter.hxx
+++ b/include/itkMorphologicalSharpeningImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMorphologicalSharpeningImageFilter_hxx
 #define itkMorphologicalSharpeningImageFilter_hxx
 
-#include "itkMorphologicalSharpeningImageFilter.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk

--- a/include/itkMorphologicalSignedDistanceTransformImageFilter.hxx
+++ b/include/itkMorphologicalSignedDistanceTransformImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkMorphologicalSignedDistanceTransformImageFilter_hxx
 #define itkMorphologicalSignedDistanceTransformImageFilter_hxx
 
-#include "itkMorphologicalSignedDistanceTransformImageFilter.h"
 #include "itkProgressAccumulator.h"
 
 namespace itk

--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -18,7 +18,6 @@
 #ifndef itkParabolicErodeDilateImageFilter_hxx
 #define itkParabolicErodeDilateImageFilter_hxx
 
-#include "itkParabolicErodeDilateImageFilter.h"
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -21,7 +21,6 @@
 #include "itkImageRegionConstIterator.h"
 #include "itkImageRegionIterator.h"
 
-#include "itkParabolicOpenCloseImageFilter.h"
 //#define NOINDEX
 #ifndef NOINDEX
 #  include "itkImageLinearIteratorWithIndex.h"

--- a/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
+++ b/include/itkParabolicOpenCloseSafeBorderImageFilter.hxx
@@ -19,7 +19,6 @@
 #define itkParabolicOpenCloseSafeBorderImageFilter_hxx
 
 #include "itkProgressAccumulator.h"
-#include "itkParabolicOpenCloseSafeBorderImageFilter.h"
 
 namespace itk
 {


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

