### PR TITLE
STYLE: Remove m_Extreme and m_MagnitudeSign data members

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.h
+++ b/include/itkParabolicErodeDilateImageFilter.h
@@ -200,9 +200,6 @@ protected:
 private:
   RadiusType m_Scale;
 
-  typename TInputImage::PixelType m_Extreme;
-
-  int m_MagnitudeSign;
   int m_CurrentDimension;
 };
 } // end namespace itk

--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -38,19 +38,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ParabolicE
 {
   this->SetNumberOfRequiredOutputs(1);
   this->SetNumberOfRequiredInputs(1);
-  // needs to be selected according to erosion/dilation
 
-  if (doDilate)
-  {
-    //    m_Extreme = NumericTraits<PixelType>::min();
-    m_Extreme = NumericTraits<PixelType>::NonpositiveMin();
-    m_MagnitudeSign = 1;
-  }
-  else
-  {
-    m_Extreme = NumericTraits<PixelType>::max();
-    m_MagnitudeSign = -1;
-  }
   m_UseImageSpacing = false;
   m_ParabolicAlgorithm = INTERSECTION;
 
@@ -249,15 +237,13 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
       unsigned long LineLength = region.GetSize()[0];
       RealType      image_scale = this->GetInput()->GetSpacing()[0];
 
-      doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doDilate>(
+      doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, PixelType, OutputPixelType, doDilate>(
         inputIterator,
         outputIterator,
         *progress,
         LineLength,
         0,
-        this->m_MagnitudeSign,
         this->m_UseImageSpacing,
-        this->m_Extreme,
         image_scale,
         this->m_Scale[0],
         m_ParabolicAlgorithm);
@@ -288,15 +274,13 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
       // RealType magnitude = 1.0/(2.0 * m_Scale[dd]);
       RealType image_scale = this->GetInput()->GetSpacing()[m_CurrentDimension];
 
-      doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, doDilate>(
+      doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, PixelType, OutputPixelType, doDilate>(
         inputIteratorStage2,
         outputIterator,
         *progress,
         LineLength,
         m_CurrentDimension,
-        this->m_MagnitudeSign,
         this->m_UseImageSpacing,
-        this->m_Extreme,
         image_scale,
         this->m_Scale[m_CurrentDimension],
         m_ParabolicAlgorithm);

--- a/include/itkParabolicOpenCloseImageFilter.h
+++ b/include/itkParabolicOpenCloseImageFilter.h
@@ -167,13 +167,6 @@ protected:
 private:
   RadiusType m_Scale;
 
-  typename TInputImage::PixelType m_Extreme;
-  typename TInputImage::PixelType m_Extreme1;
-  typename TInputImage::PixelType m_Extreme2;
-
-  int  m_MagnitudeSign;
-  int  m_MagnitudeSign1;
-  int  m_MagnitudeSign2;
   int  m_CurrentDimension;
   int  m_Stage;
   bool m_UseImageSpacing;

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -40,24 +40,6 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ParabolicOpenC
   this->SetNumberOfRequiredOutputs(1);
   this->SetNumberOfRequiredInputs(1);
   // needs to be selected according to erosion/dilation
-  if (DoOpen)
-  {
-    // erosion then dilation
-    m_Extreme1 = NumericTraits<PixelType>::max();
-    m_Extreme2 = NumericTraits<PixelType>::NonpositiveMin();
-    m_MagnitudeSign1 = -1;
-    m_MagnitudeSign2 = 1;
-  }
-  else
-  {
-    // dilation then erosion
-    m_Extreme1 = NumericTraits<PixelType>::NonpositiveMin();
-    m_Extreme2 = NumericTraits<PixelType>::max();
-    m_MagnitudeSign1 = 1;
-    m_MagnitudeSign2 = -1;
-  }
-  m_Extreme = m_Extreme1;
-  m_MagnitudeSign = m_MagnitudeSign1;
   m_UseImageSpacing = false;
   m_ParabolicAlgorithm = INTERSECTION;
   m_Stage = 1; // indicate whether we are on the first pass or the
@@ -208,9 +190,6 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::GenerateData()
     m_CurrentDimension = d;
     multithreader->SingleMethodExecute();
   }
-  // swap over the parameters controlling erosion/dilation
-  m_Extreme = m_Extreme2;
-  m_MagnitudeSign = m_MagnitudeSign2;
 
   // multithread the execution - stage 2
   m_Stage = 2;
@@ -220,9 +199,6 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::GenerateData()
     multithreader->SingleMethodExecute();
   }
 
-  // swap them back
-  m_Extreme = m_Extreme1;
-  m_MagnitudeSign = m_MagnitudeSign1;
   m_Stage = 1;
 
 #if 0
@@ -323,15 +299,13 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
         unsigned long LineLength = region.GetSize()[0];
         RealType      image_scale = this->GetInput()->GetSpacing()[0];
 
-        doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !DoOpen>(
+        doOneDimension<InputConstIteratorType, OutputIteratorType, RealType, PixelType, OutputPixelType, !DoOpen>(
           inputIterator,
           outputIterator,
           *progress,
           LineLength,
           0,
-          this->m_MagnitudeSign,
           this->m_UseImageSpacing,
-          this->m_Extreme,
           image_scale,
           this->m_Scale[0],
           m_ParabolicAlgorithm);
@@ -360,15 +334,13 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
         unsigned long LineLength = region.GetSize()[m_CurrentDimension];
         RealType      image_scale = this->GetInput()->GetSpacing()[m_CurrentDimension];
 
-        doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, !DoOpen>(
+        doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, PixelType, OutputPixelType, !DoOpen>(
           inputIteratorStage2,
           outputIterator,
           *progress,
           LineLength,
           m_CurrentDimension,
-          this->m_MagnitudeSign,
           this->m_UseImageSpacing,
-          this->m_Extreme,
           image_scale,
           this->m_Scale[m_CurrentDimension],
           m_ParabolicAlgorithm);
@@ -384,15 +356,13 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
       unsigned long LineLength = region.GetSize()[m_CurrentDimension];
       RealType      image_scale = this->GetInput()->GetSpacing()[m_CurrentDimension];
 
-      doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, OutputPixelType, DoOpen>(
+      doOneDimension<OutputConstIteratorType, OutputIteratorType, RealType, PixelType, OutputPixelType, DoOpen>(
         inputIteratorStage2,
         outputIterator,
         *progress,
         LineLength,
         m_CurrentDimension,
-        this->m_MagnitudeSign,
         this->m_UseImageSpacing,
-        this->m_Extreme,
         image_scale,
         this->m_Scale[m_CurrentDimension],
         m_ParabolicAlgorithm);


### PR DESCRIPTION
The "magnitude sign" fully depends on `doDilate`, and the "extreme" just depends on `doDilate` and the input pixel type. Both values can be estimated at compile-time, so it is not necessary to have member variables for those values.

This commit might yield some performance improvement.