### PR TITLE
STYLE: Compute numberOfRows only for the current dimension

### DIFF
--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -183,28 +183,21 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::ThreadedGe
   ThreadIdType                  threadId)
 {
   // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector<unsigned int> NumberOfRows;
-  InputSizeType                      size = outputRegionForThread.GetSize();
+  unsigned int  numberOfRows = 1;
+  InputSizeType size = outputRegionForThread.GetSize();
 
-  for (unsigned int i = 0; i < InputImageDimension; i++)
+  for (unsigned int d = 0; d < InputImageDimension; ++d)
   {
-    NumberOfRows.push_back(1);
-    for (unsigned int d = 0; d < InputImageDimension; d++)
+    if (d != m_CurrentDimension)
     {
-      if (d != i)
-      {
-        NumberOfRows[i] *= size[d];
-      }
+      numberOfRows *= size[d];
     }
   }
+
   float progressPerDimension = 1.0 / ImageDimension;
 
-  ProgressReporter progress(this,
-                            threadId,
-                            NumberOfRows[m_CurrentDimension],
-                            30,
-                            m_CurrentDimension * progressPerDimension,
-                            progressPerDimension);
+  ProgressReporter progress(
+    this, threadId, numberOfRows, 30, m_CurrentDimension * progressPerDimension, progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex<TInputImage>;
   using OutputIteratorType = ImageLinearIteratorWithIndex<TOutputImage>;

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -242,28 +242,21 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::ThreadedGenera
   ThreadIdType                  threadId)
 {
   // compute the number of rows first, so we can setup a progress reporter
-  typename std::vector<unsigned int> NumberOfRows;
-  InputSizeType                      size = outputRegionForThread.GetSize();
+  unsigned int  numberOfRows = 1;
+  InputSizeType size = outputRegionForThread.GetSize();
 
-  for (unsigned int i = 0; i < InputImageDimension; i++)
+  for (unsigned int d = 0; d < InputImageDimension; ++d)
   {
-    NumberOfRows.push_back(1);
-    for (unsigned int d = 0; d < InputImageDimension; d++)
+    if (d != m_CurrentDimension)
     {
-      if (d != i)
-      {
-        NumberOfRows[i] *= size[d];
-      }
+      numberOfRows *= size[d];
     }
   }
+
   float progressPerDimension = 1.0 / ImageDimension;
 
-  ProgressReporter progress(this,
-                            threadId,
-                            NumberOfRows[m_CurrentDimension],
-                            30,
-                            m_CurrentDimension * progressPerDimension,
-                            progressPerDimension);
+  ProgressReporter progress(
+    this, threadId, numberOfRows, 30, m_CurrentDimension * progressPerDimension, progressPerDimension);
 
   using InputConstIteratorType = ImageLinearConstIteratorWithIndex<TInputImage>;
   using OutputIteratorType = ImageLinearIteratorWithIndex<TOutputImage>;


### PR DESCRIPTION
`ParabolicErodeDilateImageFilter` and `ParabolicOpenCloseImageFilter` should not compute the number of rows for all dimensions, but just for their `m_CurrentDimension`.

- Following elastix pull request https://github.com/SuperElastix/elastix/pull/1184 commit https://github.com/SuperElastix/elastix/commit/17b3bd0907f6bb7100c52571f80b3c5f386e47b9 "STYLE: ParabolicMorphology compute numberOfRows only for one dimension"