### PR TITLE
COMP: Update ITKRemoteModuleBuildTestPackageAction to v5.4.6

### DIFF
--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -9,6 +9,8 @@ jobs:
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     with:
+      itk-wheel-tag: 'v5.4.5'
+      itk-python-package-tag: 'v5.4.5'
       test-notebooks: false
     secrets:
       pypi_password: ${{ secrets.pypi_password }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -4,10 +4,10 @@ on: [push,pull_request]
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.6
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.5
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.6
     with:
       test-notebooks: false
     secrets:

--- a/include/itkParabolicErodeDilateImageFilter.hxx
+++ b/include/itkParabolicErodeDilateImageFilter.hxx
@@ -164,7 +164,7 @@ ParabolicErodeDilateImageFilter<TInputImage, doDilate, TOutputImage>::GenerateDa
   typename ImageSource<OutputImageType>::ThreadStruct str;
   str.Filter = this;
 
-  ProcessObject::MultiThreaderType * multithreader = this->GetMultiThreader();
+  itk::MultiThreaderBase * multithreader = this->GetMultiThreader();
   multithreader->SetNumberOfWorkUnits(nbthreads);
   multithreader->SetSingleMethod(this->ThreaderCallback, &str);
 

--- a/include/itkParabolicOpenCloseImageFilter.hxx
+++ b/include/itkParabolicOpenCloseImageFilter.hxx
@@ -176,7 +176,7 @@ ParabolicOpenCloseImageFilter<TInputImage, DoOpen, TOutputImage>::GenerateData()
   typename ImageSource<OutputImageType>::ThreadStruct str;
   str.Filter = this;
 
-  ProcessObject::MultiThreaderType * multithreader = this->GetMultiThreader();
+  itk::MultiThreaderBase * multithreader = this->GetMultiThreader();
   multithreader->SetNumberOfWorkUnits(nbthreads);
   multithreader->SetSingleMethod(this->ThreaderCallback, &str);
 


### PR DESCRIPTION
## Summary
- Bump reusable workflow from the previous pinned version to v5.4.6
- v5.4.6 includes GHCR-mirrored dockcross image pre-pull with retry for more reliable Python wheel builds

See InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction#124 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)